### PR TITLE
Do not quote atoms ending with ! or ?

### DIFF
--- a/src/efe_pp.erl
+++ b/src/efe_pp.erl
@@ -610,7 +610,7 @@ maybe_quote_atom_str(Chars) ->
     end.
 
 should_quote_atom_str(Chars) ->
-    case re:run(Chars, "^[a-zA-Z_][a-zA-Z0-9@_]*$") of
+    case re:run(Chars, "^[a-zA-Z_][a-zA-Z0-9@_]*[?!]?$") of
         nomatch ->
             true;
         {match, _} ->


### PR DESCRIPTION
When transpiling Efe, I was several warnings when functions end with ! or ?
such as:
> warning: found quoted atom "alias!" but the quotes are not required. Atoms made exclusively of ASCII letters, numbers, and underscore do not require quotes
>   lib/efe_pp.ex:2956

As stated in the Syntax Reference of Elixir
https://hexdocs.pm/elixir/syntax-reference.html#atoms

> Unquoted atoms start with a colon (:) which must be immediately followed by
> a Unicode letter or an underscore. The atom may continue using a sequence of
> Unicode letters, numbers, underscores, and @. Atoms may end in ! or ?.