### PR TITLE
Update instructions to link instead of copying binary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Here's a blogpost with more details: http://marianoguerra.org/posts/elixir-flavo
 
 ```sh
 rebar3 escriptize
-cp _build/default/bin/efe .
+ln _build/default/bin/efe .
 ```
 
 ## Run


### PR DESCRIPTION
By using `ln` instead of `cp`, on rebuilds, we only need to run
`rebar3 escriptize`